### PR TITLE
Quicklook OS X plugin base (doesn't work now)

### DIFF
--- a/wlx/quicklook/quicklook.h
+++ b/wlx/quicklook/quicklook.h
@@ -1,0 +1,6 @@
+#import <Foundation/Foundation.h>
+#import <Quartz/Quartz.h>
+
+@interface QLItem: NSObject <QLPreviewItem>
+    @property NSURL* previewItemURL;
+@end

--- a/wlx/quicklook/quicklook.mm
+++ b/wlx/quicklook/quicklook.mm
@@ -1,0 +1,34 @@
+#import "quicklook.h"
+//#include <QWidget>
+#include "QtGui/QWidget"
+
+@implementation QLItem
+@end
+
+extern "C" {
+
+void* ListLoad(void* parentWin, char* fileToLoad, int showFlags) {
+    QWidget* parent = (QWidget*)parentWin;
+
+    QLItem* item = [QLItem new];
+    NSString* path = [NSString stringWithCString:fileToLoad encoding:NSUTF8StringEncoding];
+    NSURL* url = [NSURL URLWithString:path];
+    item.previewItemURL = url;
+
+    NSView* parentView = (NSView*)parent->winId();
+    CGRect frame = parentView.bounds;
+    QLPreviewView* qlView = [[QLPreviewView alloc] initWithFrame:frame style:QLPreviewViewStyleNormal];
+    [qlView setPreviewItem:item];
+    [parentView addSubview:qlView];
+    return qlView;
+}
+
+void ListCloseWindow(void* listWin) {
+    [((NSView*)listWin) removeFromSuperview];
+}
+
+void /*DCPCALL*/ ListGetDetectString(char* detectString, int maxlen) {
+    strncpy(detectString, "(EXT=\"*\")", maxlen);
+}
+
+}


### PR DESCRIPTION
This is plugin base. I can't make it work now.
The problem is possible in linked QtGui.framework, which is differs from DoubleCommander uses.

Compile with
`clang++ -framework Foundation -framework Quartz -dynamiclib quicklook.mm -o quicklook.wlx -Xlinker -v -F /usr/local/Frameworks/ -framework QtGui`

Plugin is loads and can be enabled in DC. It shows proper DetectString in DC UI. But crashes on file open:

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
…
5   QtCore                          0x000000010f0d94c9 qFatal(char const*, ...) + 159
6   QtGui                           0x0000000110a0b933 qt_pixmap_thread_test() + 114
7   QtGui                           0x0000000110a0c081 QPixmap::QPixmap(QPixmap const&) + 45
8   QtGui                           0x0000000110a5fd7a QBrush::texture() const + 34
9   QtGui                           0x0000000110a5ff5b QBrush::isOpaque() const + 193
10  QtGui                           0x00000001109b92e8 QWidgetPrivate::updateIsOpaque() + 190
11  QtGui                           0x00000001109ba77c QWidget::create(long, bool, bool) + 370
12  QtGui                           0x00000001109bb414 QWidgetPrivate::createWinId(long) + 134
13  QtGui                           0x00000001109bb414 QWidgetPrivate::createWinId(long) + 134
14  QtGui                           0x00000001109bdf71 QWidget::winId() const + 63
15  quicklook.wlx                   0x000000010b992a19 ListLoad + 169
16  com.company.doublecmd           0x00000001003a78cd 0x100000000 + 3832013
```
